### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: yarn install
+    command: yarn run start

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/bjornmagnusson/express-demo) 
+
 [![Codefresh build status]( https://g.codefresh.io/api/badges/build?repoOwner=bjornmagnusson&repoName=express-demo&branch=master&pipelineName=express-demo&accountName=bjornmagnusson&type=cf-1)]( https://g.codefresh.io/repositories/bjornmagnusson/express-demo/builds?filter=trigger:build;branch:master;service:5aa3d9854ab14c0001bc0ec8~express-demo)
 
 [![Codefresh Helm Release Status]( https://g.codefresh.io/api/badges/release?type=cf-1&key=eyJhbGciOiJIUzI1NiJ9.NWE5ZWU1OGU2OTNiYzcwMDAxY2Y4NTQy.6tvXEnmBuJziF--yHH_3NxIv5fGaQ51zuemlPaZQZnQ&selector=micro@codefresh&name=express-demo&tillerNamespace=kube-system)]( https://g.codefresh.io/helm/releases/micro@codefresh/kube-system/express-demo/services)


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.